### PR TITLE
fix(action): update git

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Download cURL
+    - name: Download cURL & update Git
       run: |
+        sudo apt-add-repository ppa:git-core/ppa
         sudo apt-get update
         sudo apt-get install -y curl
+        sudo apt-get install -y git
       shell: bash
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Download Detekt Configuration
       run: |
         echo 'Downloading configuration'


### PR DESCRIPTION
The issue with the current workflow is that on our selfhosted runners, the git version is outdated.
This is kinda a hack to install a newer version of git before running the checkout