### PR TITLE
ci: Allow for 7 throws

### DIFF
--- a/conf/detekt.yml
+++ b/conf/detekt.yml
@@ -692,7 +692,7 @@ style:
     active: false
   ThrowsCount:
     active: true
-    max: 2
+    max: 7
     excludeGuardClauses: false
   TrailingWhitespace:
     active: false


### PR DESCRIPTION
We use Exceptions for error control throw and 2 is too few. Why 7 you ask?
- it is a nice prime number
- often used in fairy tales
- off by one from a real computer number